### PR TITLE
Replace set with depset

### DIFF
--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -178,7 +178,7 @@ def _emit_build_action(ctx, project_dir):
     project_dir: A string, the main directory of the PlatformIO project.
       This is where the zip files will be extracted.
   """
-  transitive_zip_files = set()
+  transitive_zip_files = depset()
   for dep in ctx.attr.deps:
     transitive_zip_files += dep.transitive_zip_files
 

--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -122,7 +122,7 @@ def _platformio_library_impl(ctx):
   )
 
   # Collect the zip files produced by all transitive dependancies.
-  transitive_zip_files=set([ctx.outputs.zip])
+  transitive_zip_files=depset([ctx.outputs.zip])
   for dep in ctx.attr.deps:
     transitive_zip_files += dep.transitive_zip_files
   return struct(


### PR DESCRIPTION
Newer versions of bazel require depset instead of set.